### PR TITLE
test related classes moved to autoload-dev section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,12 @@
     "minimum-stability": "stable",
     "autoload": {
         "psr-4": {
-            "GodsDev\\MyCMS\\": ["classes/"],
+            "GodsDev\\MyCMS\\": ["classes/"]
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "GodsDev\\MyCMS\\Test\\": ["classes/Test/"],
             "GodsDev\\mycmsprojectnamespace\\": ["dist/classes/"]
         }
     }

--- a/dist/composer.json
+++ b/dist/composer.json
@@ -28,5 +28,10 @@
         "psr-4": {
             "GodsDev\\mycmsprojectnamespace\\": ["classes/"]
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "GodsDev\\mycmsprojectnamespace\\Test\\": ["classes/Test/"]
+        }
     }
 }


### PR DESCRIPTION
test related classes moved to autoload-dev section in order to prevent Ambiguous class resolution in `dist\autoload_static.php` from
```php
        'GodsDev\\mycmsprojectnamespace\\' => 
        array (
            0 => __DIR__ . '/../..' . '/classes',
            1 => __DIR__ . '/..' . '/godsdev/mycms/dist/classes',
        ),
```
to
```php
        'GodsDev\\mycmsprojectnamespace\\' => 
        array (
            0 => __DIR__ . '/../..' . '/classes',
        ),
```
