### PR TITLE
Feature/friendly url dist patch4

### DIFF
--- a/.github/linters/phpstan.neon
+++ b/.github/linters/phpstan.neon
@@ -1,6 +1,6 @@
 includes:
-      - ../../phpstan.common.neon
-      - ../../dist/.github/linters/phpstan.neon
+      - ../../conf/phpstan.common.neon
+      - ../../dist/conf/phpstan.mycms.neon
 
 #      - ../../phpstan.neon.dist
 #      - ../../.github/linters/phpstan.neon
@@ -27,7 +27,9 @@ parameters:
 #        path: /github/workspace/dist/set-environment.php 
       -
         message: '#Reflection error: GodsDev\\Backyard\\BackyardMysqli not found.#'
-        path: ../../classes/LogMysqli.php
+        paths:
+          - ../../classes/LogMysqli.php
+          - ../../dist/prepare.php
 #      -
 #        message: '#Reflection error: GodsDev\\Backyard\\BackyardMysqli not found.#'
 #        path: /github/workspace/classes/dist/prepare.php

--- a/.github/linters/phpstan.neon
+++ b/.github/linters/phpstan.neon
@@ -31,11 +31,11 @@ parameters:
 #      -
 #        message: '#Reflection error: GodsDev\\Backyard\\BackyardMysqli not found.#'
 #        path: /github/workspace/classes/dist/prepare.php
-      -
-        message: '#Reflection error: Nette\\SmartObject not found\.#'
-        paths:
-          - ../../classes/MyTableLister.php
-          - ../../classes/MyCMSMonoLingual.php
-#      - '#Reflection error: Nette\\SmartObject not found\.#'
+      #-
+    #    message: '#Reflection error: Nette\\SmartObject not found\.#'
+      #  paths:
+       #   - ../../classes/MyTableLister.php
+     #     - ../../classes/MyCMSMonoLingual.php
+      - '#Reflection error: Nette\\SmartObject not found\.#'
 #      - '#Call to static method barDump\(\) on an unknown class Tracy\\Debugger.#'
 #      - '#Call to static method addMessage\(\) on an unknown class GodsDev\\Tools\\Tools.#'

--- a/.github/linters/phpstan.neon
+++ b/.github/linters/phpstan.neon
@@ -2,42 +2,19 @@ includes:
       - ../../conf/phpstan.common.neon
       - ../../dist/conf/phpstan.mycms.neon
 
-#      - ../../phpstan.neon.dist
-#      - ../../.github/linters/phpstan.neon
-#
 parameters:
     scanDirectories:
       - ../../classes
-#      - ../../dist/classes
     ignoreErrors:
       -
         message: '#Reflection error: Tracy\\IBarPanel not found.#'
         path: ../../classes/Tracy/BarPanelTemplate.php
-#      -
-#        message: '#Reflection error: Phinx\\Migration\\AbstractMigration not found.#' 
-#        path: /github/workspace/dist/db/migrations/*.php
       - 
         message: '#Reflection error: PHPUnit_Framework_TestCase not found.#'
         path: ../../Test/*.php
-#      - 
-#        message: '#Reflection error: PHPUnit_Framework_TestCase not found.#'
-#        path: /github/workspace/dist/Test/*.php
-#      -
-#        message: '#Parameter \#2 \$newvalue of function ini_set expects string, true given.#'
-#        path: /github/workspace/dist/set-environment.php 
       -
         message: '#Reflection error: GodsDev\\Backyard\\BackyardMysqli not found.#'
         paths:
           - ../../classes/LogMysqli.php
           - ../../dist/prepare.php
-#      -
-#        message: '#Reflection error: GodsDev\\Backyard\\BackyardMysqli not found.#'
-#        path: /github/workspace/classes/dist/prepare.php
-      #-
-    #    message: '#Reflection error: Nette\\SmartObject not found\.#'
-      #  paths:
-       #   - ../../classes/MyTableLister.php
-     #     - ../../classes/MyCMSMonoLingual.php
       - '#Reflection error: Nette\\SmartObject not found\.#'
-#      - '#Call to static method barDump\(\) on an unknown class Tracy\\Debugger.#'
-#      - '#Call to static method addMessage\(\) on an unknown class GodsDev\\Tools\\Tools.#'

--- a/.github/workflows/phplint.yml
+++ b/.github/workflows/phplint.yml
@@ -4,5 +4,5 @@ jobs:
   phplint:
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v1
+        - uses: actions/checkout@v2
         - uses: michaelw90/PHP-Lint@master

--- a/classes/LogMysqli.php
+++ b/classes/LogMysqli.php
@@ -258,7 +258,7 @@ class LogMysqli extends BackyardMysqli
      * Example: 'SELECT id,name,surname FROM employees' --> [3=>[name=>"John", surname=>"Smith"], [...]]
      * If the first column is non-unique, results are joined into an array.
      * Example: 'SELECT department_id,name FROM employees' --> [1=>['John', 'Mary'], 2=>['Joe','Pete','Sally']]
-     * Example: 'SELECT division_id,name,surname FROM employees' --> 
+     * Example: 'SELECT division_id,name,surname FROM employees' -->
      *     [1=>[[name=>'John',surname=>'Doe'], [name=>'Mary',surname=>'Saint']], 2=>[...]]
      *
      * @param string $sql SQL to be executed
@@ -296,7 +296,7 @@ class LogMysqli extends BackyardMysqli
     /**
      * Extract data from an array and present it as values, field names, or pairs.
      * @example: $data = ['id'=>5, 'name'=>'John', 'surname'=>'Doe'];
-     * $sql = 'INSERT INTO employees (' . $this->values($data, 'fields') 
+     * $sql = 'INSERT INTO employees (' . $this->values($data, 'fields')
      *     . ') VALUES (' . $this->values($data, 'values') . ')';
      * $sql = 'UPDATE employees SET ' . $this->values($data, 'pairs') . ' WHERE id=5';
      *

--- a/classes/LogMysqli.php
+++ b/classes/LogMysqli.php
@@ -262,7 +262,7 @@ class LogMysqli extends BackyardMysqli
      *     [1=>[[name=>'John',surname=>'Doe'], [name=>'Mary',surname=>'Saint']], 2=>[...]]
      *
      * @param string $sql SQL to be executed
-     * @return mixed - either associative array, empty array on empty SELECT, or false on error
+     * @return array|false - either associative array, empty array on empty SELECT, or false on error
      */
     public function fetchAndReindex($sql)
     {

--- a/classes/MyCMS.php
+++ b/classes/MyCMS.php
@@ -95,7 +95,7 @@ class MyCMS extends MyCMSMonoLingual
      * Returns original text if translation not found.
      *
      * @param string $id text to translate
-     * @param mixed $options case transposition - null || [MB_CASE_UPPER|MB_CASE_LOWER|MB_CASE_TITLE|L_UCFIRST]
+     * @param int|null $options case transposition - null || [MB_CASE_UPPER|MB_CASE_LOWER|MB_CASE_TITLE|L_UCFIRST]
      * @return string
      */
     public function translate($id, $options = null)

--- a/classes/MyCMSMonoLingual.php
+++ b/classes/MyCMSMonoLingual.php
@@ -123,6 +123,11 @@ class MyCMSMonoLingual
         return $this->dbms->fetchAll($sql);
     }
 
+    /**
+     *
+     * @param string $sql SQL to be executed
+     * @return array|false - either associative array, empty array on empty SELECT, or false on error
+     */
     public function fetchAndReindex($sql)
     {
         return $this->dbms->fetchAndReindex($sql);

--- a/classes/MyFriendlyUrl.php
+++ b/classes/MyFriendlyUrl.php
@@ -107,7 +107,7 @@ class MyFriendlyUrl extends MyCommon
      * matchResult = (1=pattern matches `PARSE_PATH_PATTERN`, 0=it does not, or FALSE=error)
      *
      * @param array $options
-     * @return mixed `bool (true)` when `TEMPLATE_NOT_FOUND` || `array` with redir string field
+     * @return array|true `bool (true)` when `TEMPLATE_NOT_FOUND` || `array` with redir string field
      *     || `array` with token string field and matches array field (see above)
      */
     protected function friendlyIdentifyRedirect(array $options = [])
@@ -240,7 +240,7 @@ class MyFriendlyUrl extends MyCommon
     /**
      * Checks rules against current get parameters
      *
-     * @return mixed string template name on success, null on necessity to continue
+     * @return string|null string template name on success, null on necessity to continue
      */
     private function parametricRuleToTemplate()
     {
@@ -435,7 +435,7 @@ class MyFriendlyUrl extends MyCommon
      *
      * @param string $outputKey `type`
      * @param string $outputValue `id`
-     * @return mixed null (do not change the output) or string (URL - friendly or parametric)
+     * @return string|null null (do not change the output) or string (URL - friendly or parametric)
      */
     protected function switchParametric($outputKey, $outputValue)
     {

--- a/classes/MyTableAdmin.php
+++ b/classes/MyTableAdmin.php
@@ -237,7 +237,7 @@ class MyTableAdmin extends MyTableLister
             case 'mediumint':
             case 'bigint':
             case 'year':
-                // TODO fix Binary operation "+=" between arrays results in an error. 
+                // TODO fix Binary operation "+=" between arrays results in an error.
                 $input += ['type' => 'number', 'step' => 1, 'class' => 'form-control'];
                 if ($field['key'] == 'PRI') {
                     $input['readonly'] = 'readonly';
@@ -303,7 +303,7 @@ class MyTableAdmin extends MyTableLister
                 foreach ($choices as $k => $v) {
                     $tmp[$k] = Tools::htmlInput("fields[$key][$k]", $v === '' ? '<i>' . $this->translate('nothing') . '</i>' : $v, 1 << $k, [
                             'type' => 'checkbox',
-                            // todo ask CRS2 is_array($value) seeems to be always true, so Else branch is unreachable because ternary operator condition is always true. 
+                            // todo ask CRS2 is_array($value) seeems to be always true, so Else branch is unreachable because ternary operator condition is always true.
                             'checked' => ((1 << $k) & (int) (is_array($value) ? reset($value) : $value)) ? 'checked' : null,
                             'id' => "$key-$k-$this->rand",
                             'label-html' => $v === '',

--- a/classes/MyTableLister.php
+++ b/classes/MyTableLister.php
@@ -183,9 +183,9 @@ class MyTableLister
             throw new \RunTimeException('Could not get columns from table ' . $this->table . '.');
         }
         $query = $this->dbms->query(
-            'SELECT COLUMN_NAME,REFERENCED_TABLE_NAME,REFERENCED_COLUMN_NAME 
-            FROM information_schema.KEY_COLUMN_USAGE WHERE CONSTRAINT_NAME != "PRIMARY" AND CONSTRAINT_CATALOG = "def" 
-            AND TABLE_SCHEMA = "' . $this->escapeSQL($this->database) . '" 
+            'SELECT COLUMN_NAME,REFERENCED_TABLE_NAME,REFERENCED_COLUMN_NAME
+            FROM information_schema.KEY_COLUMN_USAGE WHERE CONSTRAINT_NAME != "PRIMARY" AND CONSTRAINT_CATALOG = "def"
+            AND TABLE_SCHEMA = "' . $this->escapeSQL($this->database) . '"
             AND TABLE_NAME = "' . $this->escapeSQL($this->table) . '"'
         );
         if ($query) {
@@ -473,7 +473,7 @@ class MyTableLister
                 <span class="glyphicon glyphicon-list-alt fa fa-list-alt"></span>
             </button>
             </fieldset></form>
-            <script type="text/javascript"> 
+            <script type="text/javascript">
             LISTED_FIELDS=[' . Tools::arrayListed(array_keys($this->fields), 4, ',', '"', '"') . '];' . PHP_EOL;
         if (isset($_GET['col'], $_GET['op']) && is_array($_GET['col'])) {
             foreach ($_GET['col'] as $key => $value) {
@@ -578,7 +578,7 @@ class MyTableLister
         }
         $output .= '</tbody></table>' . PHP_EOL;
         if (!isset($options['no-selected-rows-operations'])) {
-            $output .= '<div class="selected-rows mb-2"><i class="fa fa-check-square"></i>=<span class="listed">0</span> 
+            $output .= '<div class="selected-rows mb-2"><i class="fa fa-check-square"></i>=<span class="listed">0</span>
                 <label class="btn btn-sm btn-light mx-1 mt-2">' . Tools::htmlInput('total-rows', '', $options['total-rows'], ['type' => 'checkbox', 'class' => 'total-rows']) . ' ' . $this->translate('Whole resultset') . '</label>
                 <button name="table-export" value="1" class="btn btn-sm ml-1" disabled="disabled"><i class="fa fa-download"></i> ' . $this->translate('Export') . '</button>
                 <button name="edit-selected" value="1" class="btn btn-sm ml-1" disabled="disabled"><i class="fa fa-edit"></i> ' . $this->translate('Edit') . '</button>
@@ -739,7 +739,8 @@ class MyTableLister
      * @param mixed $noChangeMessage optional message in case of no affected change
      *   false = use $successMessage
      *
-     * @return mixed true for success, false for failure of the query; if the query is empty return null (with no messages)
+     * @return bool|null true for success, false for failure of the query;
+     *   if the query is empty return null (with no messages)
      */
     public function resolveSQL($sql, $successMessage, $errorMessage, $noChangeMessage = false)
     {

--- a/classes/Tracy/BarPanelTemplate.php
+++ b/classes/Tracy/BarPanelTemplate.php
@@ -10,7 +10,6 @@ use Tracy\IBarPanel;
  */
 class BarPanelTemplate implements IBarPanel
 {
-
     protected $tabTitle;
 
     protected $panelDetails;

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "nette/utils": "^2.4.8",
         "texy/texy": "^2.7.1",
         "godsdev/tools": "dev-feature/phpstan-corrections",
-        "godsdev/backyard": "3.2.9",
+        "godsdev/backyard": "3.2.10",
         "ext-session": "*",
         "ext-mbstring": "*"
     },

--- a/conf/phpstan.common.neon
+++ b/conf/phpstan.common.neon
@@ -1,0 +1,5 @@
+parameters:
+    level: 5
+    bootstrapFiles:
+      - ../conf/config.php
+      - ../.github/linters/conf/constants.php

--- a/conf/phpstan.common.neon
+++ b/conf/phpstan.common.neon
@@ -1,5 +1,5 @@
 parameters:
     level: 5
     bootstrapFiles:
-      - ../conf/config.php
-      - ../.github/linters/conf/constants.php
+      - config.php
+      #- ../.github/linters/conf/constants.php # uncomment if needed

--- a/dist/.github/linters/phpstan.neon
+++ b/dist/.github/linters/phpstan.neon
@@ -1,11 +1,8 @@
 includes:
-      - ../../phpstan.common.neon
+      - ../../conf/phpstan.mycms.neon
 
 parameters:
     ignoreErrors:
-      - 
-        message: '#Reflection error: PHPUnit_Framework_TestCase not found.#'
-        path: ../../Test/*.php
       -
         message: '#Reflection error: GodsDev\\MyCMS\\MyAdmin not found\.#'
         path: ../../classes/Admin.php
@@ -27,20 +24,8 @@ parameters:
         message: '#Reflection error: GodsDev\\MyCMS\\ProjectCommon not found.#'
         path: ../../classes/ProjectSpecific.php
       -
-        message: '#Reflection error: Phinx\\Migration\\AbstractMigration not found.#'
-        path: ../../db/migrations/*.php
-      -
         message: '#Reflection error: GodsDev\\MyCMS\\MyTableAdmin not found\.#'
         paths:
           - ../../admin.php
           - ../../classes/TableAdmin.php
-      -
-        message: '#Call to static method addMessage\(\) on an unknown class GodsDev\\Tools\\Tools.#'
-        path: ../../process.php
-      -
-        message: '#Reflection error: Nette\\SmartObject not found\.#'
-        path: ../../classes/Latte/CustomFilters.php
-      -
-        message: '#Call to static method redir\(\) on an unknown class GodsDev\\Tools\\Tools.#'
-        path: ../../process.php
       - '#Reflection error: GodsDev\\MyCMS\\MyController not found.#'

--- a/dist/classes/AdminProcess.php
+++ b/dist/classes/AdminProcess.php
@@ -250,7 +250,7 @@ class AdminProcess extends MyAdminProcess
             'CONCAT(REPEAT("… ",LENGTH(' . $this->MyCMS->dbms->escapeDbIdentifier($options['path']) . ') / '
             . PATH_MODULE . ' - 1),' . $options['table'] . '_' . DEFAULT_LANGUAGE . ')' :
             (isset($options['column']) ? (
-            is_array($options['column']) ? ('CONCAT(' .
+                is_array($options['column']) ? ('CONCAT(' .
                 implode(
                     ",'|',",
                     array_map([$this->MyCMS->dbms, 'escapeDbIdentifier'], $options['column'])

--- a/dist/classes/FriendlyUrl.php
+++ b/dist/classes/FriendlyUrl.php
@@ -72,7 +72,7 @@ class FriendlyUrl extends MyFriendlyUrl
      *
      * @param string $outputKey `type`
      * @param string $outputValue `id`
-     * @return mixed null (do not change the output) or string (URL - friendly or parametric)
+     * @return string|null null (do not change the output) or string (URL - friendly or parametric)
      */
     protected function switchParametric($outputKey, $outputValue)
     {

--- a/dist/classes/Mail.php
+++ b/dist/classes/Mail.php
@@ -80,7 +80,7 @@ class Mail extends MyCommon
      * @param string $subject
      * @param string $messageTxt
      * @param array $options
-     * @return mixed false or int
+     * @return int|false
      */
     public function sendMail($to, $subject, $messageTxt, array $options = [])
     {

--- a/dist/classes/ProjectSpecific.php
+++ b/dist/classes/ProjectSpecific.php
@@ -147,7 +147,7 @@ class ProjectSpecific extends ProjectCommon
      * Retrieves product info
      *
      * @param int $id
-     * @return mixed array first selected row, null on empty SELECT
+     * @return array|null array first selected row, null on empty SELECT
      * @throws \Exception on error
      */
     public function getProduct($id)
@@ -178,7 +178,7 @@ class ProjectSpecific extends ProjectCommon
      *
      * @param string $path
      * @param array $options OPTIONAL
-     * @return mixed
+     * @return array|false
      */
     public function getBreadcrumbs($path, array $options = array())
     {
@@ -199,20 +199,20 @@ class ProjectSpecific extends ProjectCommon
      * Get "children" content to a specified category/ies
      * TODO: make this method useful for dist project as a demonstration
      *
-     * @param mixed $category_id category/ies to search, either int or array of integers
+     * @param int|array<int> $category_id category/ies to search, either int or array of integers
      * @param array $options = []
      *          [path] - path of the category
      *          [level] - level to which seek for children
      *          [except_id] - id of the child to omit from the result
-     * @return mixed - either associative array, empty array on empty SELECT, or false on error
+     * @return array|false - either associative array, empty array on empty SELECT, or false on error
      */
     public function getChildren($category_id, array $options = [])
     {
         Tools::setifnotset($options['level'], 0);
         if ($options['level'] && Tools::nonzero($options['path'])) {
-            $category_id = array_keys($this->MyCMS->fetchAndReindex($sql = 'SELECT id FROM ' . TAB_PREFIX . 'category 
+            $category_id = array_keys($this->MyCMS->fetchAndReindex($sql = 'SELECT id FROM ' . TAB_PREFIX . 'category
                 WHERE LEFT(path, ' . strlen($options['path']) . ')="' . $this->MyCMS->escapeSQL($options['path']) . '"
-                AND LENGTH(path) > ' . strlen($options['path']) . ' 
+                AND LENGTH(path) > ' . strlen($options['path']) . '
                 AND LENGTH(path) <= ' . (strlen($options['path']) + $options['level'] * PATH_MODULE)));
         } else {
             $category_id = array($category_id);

--- a/dist/conf/config.php
+++ b/dist/conf/config.php
@@ -9,7 +9,7 @@
  */
 
 ini_set('session.use_strict_mode', '1');
-ini_set('display_errors', '0'); // errors only in the log; override it in your config.local.php if you need
+ini_set('display_errors', '0'); // errors only in the log; override it in your config.local.php if you need to
 
 define('DB_HOST', 'localhost');
 define('DB_PORT', ini_get('mysqli.default_port'));

--- a/dist/conf/phpstan.common.neon
+++ b/dist/conf/phpstan.common.neon
@@ -1,9 +1,9 @@
 parameters:
     level: 5
     bootstrapFiles:
-      - conf/config.php
-      - conf/config.local.dist.php
-      - .github/linters/conf/constants.php
+      - config.php
+      - config.local.dist.php
+      - ../.github/linters/conf/constants.php
     scanDirectories:
       - classes
     ignoreErrors:

--- a/dist/conf/phpstan.common.neon
+++ b/dist/conf/phpstan.common.neon
@@ -2,10 +2,10 @@ parameters:
     level: 5
     bootstrapFiles:
       - config.php
-      - config.local.dist.php
-      - ../.github/linters/conf/constants.php
+      #- config.local.dist.php # comment as debugging
+      #- ../.github/linters/conf/constants.php # uncomment if needed
     scanDirectories:
-      - classes
+      - ../classes
     ignoreErrors:
       # These variables are responsibility of the including/included script
       -

--- a/dist/conf/phpstan.common.neon
+++ b/dist/conf/phpstan.common.neon
@@ -10,15 +10,15 @@ parameters:
       # These variables are responsibility of the including/included script
       -
         message: '#Variable \$MyCMS might not be defined.#'
-        path: process.php
+        path: ../process.php
       # The exceptions concerning always false/true compensate for environment dependent variables.
       -
         message: '#Right side of && is always false.#'
-        path: conf/config.php
+        path: config.php
       # Compensate for PHPUnit where $_POST may not be defined
       -
         message: '#Result of \|\| is always false.#'
-        path: process.php
+        path: ../process.php
       -
         message: '#Variable \$_POST in isset\(\) always exists and is not nullable#'
-        path: process.php
+        path: ../process.php

--- a/dist/conf/phpstan.mycms.neon
+++ b/dist/conf/phpstan.mycms.neon
@@ -5,16 +5,16 @@ parameters:
     ignoreErrors:
       -
         message: '#Reflection error: PHPUnit_Framework_TestCase not found.#'
-        path: ../../Test/*.php
+        path: ../Test/*.php
       -
         message: '#Reflection error: Phinx\\Migration\\AbstractMigration not found.#'
-        path: ../../db/migrations/*.php
+        path: ../db/migrations/*.php
       -
         message: '#Call to static method addMessage\(\) on an unknown class GodsDev\\Tools\\Tools.#'
-        path: ../../process.php
+        path: ../process.php
       -
         message: '#Reflection error: Nette\\SmartObject not found\.#'
-        path: ../../classes/Latte/CustomFilters.php
+        path: ../classes/Latte/CustomFilters.php
       -
         message: '#Call to static method redir\(\) on an unknown class GodsDev\\Tools\\Tools.#'
-        path: ../../process.php
+        path: ../process.php

--- a/dist/conf/phpstan.mycms.neon
+++ b/dist/conf/phpstan.mycms.neon
@@ -1,0 +1,20 @@
+includes:
+      - phpstan.common.neon
+
+parameters:
+    ignoreErrors:
+      -
+        message: '#Reflection error: PHPUnit_Framework_TestCase not found.#'
+        path: ../../Test/*.php
+      -
+        message: '#Reflection error: Phinx\\Migration\\AbstractMigration not found.#'
+        path: ../../db/migrations/*.php
+      -
+        message: '#Call to static method addMessage\(\) on an unknown class GodsDev\\Tools\\Tools.#'
+        path: ../../process.php
+      -
+        message: '#Reflection error: Nette\\SmartObject not found\.#'
+        path: ../../classes/Latte/CustomFilters.php
+      -
+        message: '#Call to static method redir\(\) on an unknown class GodsDev\\Tools\\Tools.#'
+        path: ../../process.php

--- a/dist/phpstan.neon.dist
+++ b/dist/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-      - phpstan.common.neon
+      - conf/phpstan.common.neon
 
 parameters:
     excludes_analyse:

--- a/dist/prepare.php
+++ b/dist/prepare.php
@@ -16,7 +16,7 @@ use Tracy\Debugger;
 session_start() || error_log('session_start failed');
 $developmentEnvironment = (
     in_array($_SERVER['REMOTE_ADDR'], array('::1', '127.0.0.1')) || in_array($_SERVER['REMOTE_ADDR'], $debugIpArray)
-    );
+);
 
 Debugger::enable($developmentEnvironment ? Debugger::DEVELOPMENT : Debugger::PRODUCTION, __DIR__ . '/log');
 Debugger::$email = EMAIL_ADMIN;

--- a/phpstan.common.neon
+++ b/phpstan.common.neon
@@ -1,5 +1,0 @@
-parameters:
-    level: 5
-    bootstrapFiles:
-      - conf/config.php
-      - .github/linters/conf/constants.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,6 @@
 includes:
-      - phpstan.common.neon
-#      - dist/phpstan.common.neon
+      - conf/phpstan.common.neon
+#      - dist/conf/phpstan.common.neon
 #includes:
       - dist/phpstan.neon.dist
 #

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,14 +8,3 @@ parameters:
       -
         message: '#Ternary operator condition is always true.#'
         path: classes/MyAdminProcess.php
-      # These variables are responsibility of the including/included script (duplicates dist/conf/phpstan.common.neon section)
-      -
-        message: '#Variable \$MyCMS might not be defined.#'
-        path: dist\process.php
-      # Compensate for PHPUnit where $_POST may not be defined (duplicates dist/conf/phpstan.common.neon section)
-      -
-        message: '#Result of \|\| is always false.#'
-        path: dist\process.php
-      -
-        message: '#Variable \$_POST in isset\(\) always exists and is not nullable#'
-        path: dist\process.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,16 +1,21 @@
 includes:
       - conf/phpstan.common.neon
-#      - dist/conf/phpstan.common.neon
-#includes:
       - dist/phpstan.neon.dist
-#
-parameters:
-#    bootstrapFiles:
-#      - conf/config.php
-#      - .github/linters/conf/constants.php
 
+parameters:
     ignoreErrors:
       # getimagesize is false in case of error
       -
         message: '#Ternary operator condition is always true.#'
         path: classes/MyAdminProcess.php
+      # These variables are responsibility of the including/included script (duplicates dist/conf/phpstan.common.neon section)
+      -
+        message: '#Variable \$MyCMS might not be defined.#'
+        path: dist\process.php
+      # Compensate for PHPUnit where $_POST may not be defined (duplicates dist/conf/phpstan.common.neon section)
+      -
+        message: '#Result of \|\| is always false.#'
+        path: dist\process.php
+      -
+        message: '#Variable \$_POST in isset\(\) always exists and is not nullable#'
+        path: dist\process.php


### PR DESCRIPTION
* Change of phpstan.neon includes, due to fact that when PHPStan test dist/ as part of MyCMS, it knows the GodsDev\\MyCMS\\* classes, so they should be ignored only if dist/ lives in its own project.
* phpstan ignoreErrors tuning
* phplint.yml uses actions/checkout@v2
* some mixed type hints replaced with more specific ones