### PR TITLE
Don't log SQL for user creation or password change

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ new Controller(['requestUri' => $_SERVER['REQUEST_URI']])
 ### TODO Administration
 * 200314: administrace FriendlyURL je v F4T/classes/Admin::outputSpecialMenuLinks() a ::sectionUrls() .. zobecnit do MyCMS a zapnout pokud FRIENDLY_URL == true
 * 200314 v Admin.php mít příslušnou editační sekci FriendlyURL (dle F4T) .. pokud lze opravdu zobecnit
-* 200526: CMS: * 200526: If Texy is used (see only in MyTableAdmin `($comment['display'] == 'html' ? ' richtext' : '') . ($comment['display'] == 'texyla' ? ' texyla' : '')` then describe it. Otherwise remove it from composer.json, Latte\CustomFilters\, ProjectCommon, dist\index.php.
+* 200526: CMS: If Texy is used (see only in MyTableAdmin `($comment['display'] == 'html' ? ' richtext' : '') . ($comment['display'] == 'texyla' ? ' texyla' : '')` then describe it. Otherwise remove it from composer.json, Latte\CustomFilters\, ProjectCommon, dist\index.php.
 
 ### TODO Governance
 * 190705: v classes\LogMysqli.php probíhá logování `'log/sql' . date("Y-m-d") . '.log.sql');` do aktuálního adresáře volajícího skriptu - což u API není výhodné. Jak vycházet z APP_ROOT?
@@ -208,6 +208,3 @@ new Controller(['requestUri' => $_SERVER['REQUEST_URI']])
 
 ### TODO SECURITY
 * 190723: pokud jsou v té samé doméně dvě různé instance MyCMS, tak přihlášením do jednoho admin.php jsem přihlášen do všech, i když ten uživatel tam ani neexistuje
-* TO BE CHECKED 190723: nastavování hesla by se nemělo do log.sql ukládat - volat instanci BackyardMysqli namísto LogMysqli??
-@crs2: Řešilo by to přidání parametru (do query() v LogMysqli.php), který by volání error_log() potlačil? A poté u změny hesla volání tohoto parametru? + Ještě mě napadá řešení
-na úrovni samotného sloupce tabulky, tj. definování (v LogMysqli.php), které sloupce které tabulky obsahují citlivé údaje pro logování. Ale to by vyžadovalo parsing SQL.

--- a/classes/LogMysqli.php
+++ b/classes/LogMysqli.php
@@ -65,7 +65,7 @@ class LogMysqli extends BackyardMysqli
     public function query($sql, $errorLogOutput = 1, $logQuery = true)
     {
         if ($logQuery && !preg_match('/^SELECT |^SET |^SHOW /i', $sql)) {
-            //mb_eregi_replace does not destroy e.g. character Š
+            //mb_eregi_replace does not destroy multi-byte characters such as character Š
             error_log(
                 trim(mb_eregi_replace('/\s+/', ' ', $sql)) . '; -- [' . date("d-M-Y H:i:s") . ']'
                 . (isset($_SESSION['user']) ? " by ({$_SESSION['user']})" : '') . PHP_EOL,

--- a/classes/MyAdminProcess.php
+++ b/classes/MyAdminProcess.php
@@ -585,7 +585,7 @@ class MyAdminProcess extends MyCommon
                             true,
                             false
                         );
-                        Debugger::log("Password for user '{$_SESSION['user']}' was changed.", ILogger::INFO);
+                        Debugger::log("User '{$_SESSION['user']}' changed password.", ILogger::INFO);
                         $this->redir();
                     }
                 }

--- a/classes/MyAdminProcess.php
+++ b/classes/MyAdminProcess.php
@@ -585,7 +585,7 @@ class MyAdminProcess extends MyCommon
                             true,
                             false
                         );
-                        Debugger::log("Password for user: {$_SESSION['user']} was changed.", ILogger::INFO);
+                        Debugger::log("Password for user '{$_SESSION['user']}' was changed.", ILogger::INFO);
                         $this->redir();
                     }
                 }
@@ -614,7 +614,7 @@ class MyAdminProcess extends MyCommon
                 $this->tableAdmin->translate('User added.'),
                 $this->tableAdmin->translate($this->MyCMS->dbms->errorDuplicateEntry() ? 'User already exists.' : 'Error occured adding the user.')
             );
-            Debugger::log("User {$_SESSION['user']} was created.", ILogger::INFO);
+            Debugger::log("User '{$post['user']}' was created by '{$_SESSION['user']}'.", ILogger::INFO);
             $this->redir();
         }
     }

--- a/classes/MyAdminProcess.php
+++ b/classes/MyAdminProcess.php
@@ -5,6 +5,7 @@ namespace GodsDev\MyCMS;
 use GodsDev\Tools\Tools;
 use GodsDev\MyCMS\MyCommon;
 use Tracy\Debugger;
+use Tracy\ILogger;
 
 /**
  * Class to process standard operations in MyCMS
@@ -572,14 +573,19 @@ class MyAdminProcess extends MyCommon
                     if ($row['active'] == '1' && $row['password_hashed'] == sha1($post['old-password'] . $row['salt'])) {
                         // TODO ask CRS2 Static method GodsDev\Tools\Tools::resolve() invoked with 5 parameters, 3 required.
                         Tools::resolve(
-                            $this->MyCMS->dbms->query('UPDATE ' . TAB_PREFIX . 'admin
+                            $this->MyCMS->dbms->query(
+                                'UPDATE ' . TAB_PREFIX . 'admin
                     SET password_hashed="' . $this->MyCMS->escapeSQL(sha1($post['new-password'] . $row['salt'])) . '"
-                    WHERE admin="' . $this->MyCMS->escapeSQL($_SESSION['user']) . '"'),
+                    WHERE admin="' . $this->MyCMS->escapeSQL($_SESSION['user']) . '"',
+                                1,
+                                false
+                            ),
                             $this->tableAdmin->translate('Password was changed.'),
                             $this->tableAdmin->translate('Error occured changing password.'),
                             true,
                             false
-                        ); // this statement MUST NOT be logged by LogMysqli mechanism
+                        );
+                        Debugger::log("Password for user: {$_SESSION['user']} was changed.", ILogger::INFO);
                         $this->redir();
                     }
                 }
@@ -600,10 +606,15 @@ class MyAdminProcess extends MyCommon
         if (isset($post['create-user'], $post['user'], $post['password'], $post['retype-password']) && $post['user'] && $post['password'] && $post['retype-password']) {
             $salt = mt_rand((int) 1e8, (int) 1e9);
             Tools::resolve(
-                $this->MyCMS->dbms->query('INSERT INTO ' . TAB_PREFIX . 'admin SET admin="' . $this->MyCMS->escapeSQL($post['user']) . '", password_hashed="' . $this->MyCMS->escapeSQL(sha1($post['password'] . $salt)) . '", salt=' . $salt . ', rights=2'),
+                $this->MyCMS->dbms->query(
+                    'INSERT INTO ' . TAB_PREFIX . 'admin SET admin="' . $this->MyCMS->escapeSQL($post['user']) . '", password_hashed="' . $this->MyCMS->escapeSQL(sha1($post['password'] . $salt)) . '", salt=' . $salt . ', rights=2',
+                    1,
+                    false
+                ),
                 $this->tableAdmin->translate('User added.'),
                 $this->tableAdmin->translate($this->MyCMS->dbms->errorDuplicateEntry() ? 'User already exists.' : 'Error occured adding the user.')
             );
+            Debugger::log("User {$_SESSION['user']} was created.", ILogger::INFO);
             $this->redir();
         }
     }


### PR DESCRIPTION
Security fix
* Don't log SQL for user creation or password change
* Log only INFO about the event of user creation or password change
