### PR TITLE
Minor admin related fixes

### DIFF
--- a/classes/MyAdmin.php
+++ b/classes/MyAdmin.php
@@ -431,9 +431,8 @@ class MyAdmin extends MyCommon
             . 'TAB_PREFIX = "' . TAB_PREFIX . '";' . PHP_EOL
             . 'EXPAND_INFIX = "' . EXPAND_INFIX . '";' . PHP_EOL
             . 'TOKEN = ' . end($_SESSION['token']) . ';' . PHP_EOL
-            // todo CRS2 fix Parameter #2 $options of function json_encode expects int, true given.
-            . 'ASSETS_SUBFOLDERS = ' . json_encode($this->ASSETS_SUBFOLDERS, true) . ';' . PHP_EOL
-            . 'DIR_ASSETS = ' . json_encode(DIR_ASSETS, true) . ';' . PHP_EOL
+            . 'ASSETS_SUBFOLDERS = ' . json_encode($this->ASSETS_SUBFOLDERS) . ';' . PHP_EOL
+            . 'DIR_ASSETS = ' . json_encode(DIR_ASSETS) . ';' . PHP_EOL
             . '$(document).ready(function(){' . PHP_EOL
             . $this->tableAdmin->script . PHP_EOL
             . 'if (typeof(AdminRecordName) != "undefined") {' . PHP_EOL

--- a/classes/MyAdminProcess.php
+++ b/classes/MyAdminProcess.php
@@ -4,6 +4,7 @@ namespace GodsDev\MyCMS;
 
 use GodsDev\Tools\Tools;
 use GodsDev\MyCMS\MyCommon;
+use GodsDev\MyCMS\MyTableAdmin;
 use Tracy\Debugger;
 use Tracy\ILogger;
 
@@ -23,7 +24,7 @@ class MyAdminProcess extends MyCommon
     /** @var int how many seconds may pass before admin's record-editing tab is considered closed */
     protected $ACTIVITY_TIME_LIMIT = 180;
 
-    /** @var \GodsDev\MyCMS\MyTableAdmin */
+    /** @var MyTableAdmin */
     protected $tableAdmin;
 
     /**

--- a/classes/MyTableLister.php
+++ b/classes/MyTableLister.php
@@ -629,7 +629,7 @@ class MyTableLister
             $offset = max(isset($_GET['offset']) ? (int) $_GET['offset'] : 0, 0);
         }
         $rowsPerPage = max($rowsPerPage, 1);
-        $pages = ceil($totalRows / $rowsPerPage);
+        $pages = (int) ceil($totalRows / $rowsPerPage);
         $currentPage = (int) floor($offset / $rowsPerPage) + 1;
         if ($pages <= 1) {
             return;
@@ -640,8 +640,7 @@ class MyTableLister
                 $output .= $this->addPage($currentPage - 1, $currentPage, $rowsPerPage, $this->translate('Previous'), $title);
             }
             for ($page = 1; $page <= $pages; $page++) {
-                // TODO ask CRS2 Method GodsDev\MyCMS\MyTableLister::addPage() invoked with 6 parameters, 3-5 required.
-                $output .= $this->addPage($page, $currentPage, $rowsPerPage, null, $this->translate('Go to page'), $title);
+                $output .= $this->addPage($page, $currentPage, $rowsPerPage, null, $title);
             }
             if ($currentPage < $pages) {
                 $output .= $this->addPage($currentPage + 1, $currentPage, $rowsPerPage, $this->translate('Next'), $title);


### PR DESCRIPTION
* MyAdmin: function json_encode shouldn't use #2 parameter
* MyTableLister: method addPage has just 5 parameters
* AdminProcess: use TableAdmin (instead of MyTableAdmin) so that $this->tableAdmin->customDelete() refers to an existing method
* MyTableAdmin: recordSave() $field instead of $value; check for $this->fields being be an array with at least one element
* If you want to append array elements from the second array to the first array while not overwriting the elements from the first array and not re-indexing, use the + array union operator: fix Binary operation "+=" between arrays results in an error ==> for simplicity and better readability use simple assignment, i.e.
`$input['class'] = 'form-control input-date';` instead of `$input += [/* 'type' => 'date', */ 'class' => 'form-control input-date'];` which should be anyway `$input = ['class' => 'form-control input-date'] + $input;`
* AdminProcess: method adminProcess() fix Binary operation "+=" between array&nonEmpty and array|false results in an error.